### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/LEDmodule5050/keywords.txt
+++ b/LEDmodule5050/keywords.txt
@@ -7,26 +7,26 @@
 #######################################
 
 FullColorLedModule	KEYWORD1
-color			KEYWORD1
+color	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Setup		KEYWORD2
-On		KEYWORD2
-Off		KEYWORD2
+Setup	KEYWORD2
+On	KEYWORD2
+Off	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-_Off			LITERAL1
-_White 			LITERAL1
-_HalfWhite 		LITERAL1
-_Green 			LITERAL1
-_Red 			LITERAL1
-_Blue 			LITERAL1
-_Margenta 		LITERAL1
-_Purple 		LITERAL1
-_Black 			LITERAL1
+_Off	LITERAL1
+_White	LITERAL1
+_HalfWhite	LITERAL1
+_Green	LITERAL1
+_Red	LITERAL1
+_Blue	LITERAL1
+_Margenta	LITERAL1
+_Purple	LITERAL1
+_Black	LITERAL1
 

--- a/SerialMP3player/keywords.txt
+++ b/SerialMP3player/keywords.txt
@@ -22,42 +22,41 @@ SerialMP3Player	KEYWORD1
 
 
 
-NextSong		KEYWORD2
+NextSong	KEYWORD2
 
-PrevSong		KEYWORD2
+PrevSong	KEYWORD2
 
-Play			KEYWORD2
+Play	KEYWORD2
 
-PlayFolder		KEYWORD2
+PlayFolder	KEYWORD2
 
-Pause			KEYWORD2
+Pause	KEYWORD2
 
-Stop			KEYWORD2
+Stop	KEYWORD2
 
-PlayRepeat		KEYWORD2
+PlayRepeat	KEYWORD2
 
-StopRepeat		KEYWORD2
+StopRepeat	KEYWORD2
 
-PlayShuffle		KEYWORD2
+PlayShuffle	KEYWORD2
 
-PlayAtVolume		KEYWORD2
+PlayAtVolume	KEYWORD2
 
-PlayGroup		KEYWORD2
+PlayGroup	KEYWORD2
 
-VolumeUp		KEYWORD2
+VolumeUp	KEYWORD2
 
-VolumeDown		KEYWORD2
+VolumeDown	KEYWORD2
 
-SetVolume		KEYWORD2
+SetVolume	KEYWORD2
 
-Mute			KEYWORD2
+Mute	KEYWORD2
 
-	
-Reset			KEYWORD2
+Reset	KEYWORD2
 
-StartDAC		KEYWORD2
+StartDAC	KEYWORD2
 
-StopDAC			KEYWORD2
+StopDAC	KEYWORD2
 
 #######################################
 

--- a/SwitchHandling/keywords.txt
+++ b/SwitchHandling/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SwitchRead		KEYWORD1
+SwitchRead	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -25,10 +25,10 @@ tcSwitch	KEYWORD2
 wtSwitch	KEYWORD2
 wtSwitch	KEYWORD2
 
-tsSitch		KEYWORD2
+tsSitch	KEYWORD2
 
-Poll		KEYWORD2
-Reset		KEYWORD2
+Poll	KEYWORD2
+Reset	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords